### PR TITLE
Event -> CustomEvent & .bind(this) => arrow func

### DIFF
--- a/lazy-image.js
+++ b/lazy-image.js
@@ -21,11 +21,11 @@ class LazyImage extends HTMLElement {
     this._img.style.width = '100%';
 
     // Bubble up this load event.
-    this._img.addEventListener('load', function() {
-      var event = new Event('load');
+    this._img.addEventListener('load', () => {
+      var event = new CustomEvent('load');
       event.detail = {originalTarget : this._img};
       this.dispatchEvent(event);
-    }.bind(this))
+    });
 
     // Add the <img> element inside the shadow root.
     const shadow = this.attachShadow({mode: 'open'});


### PR DESCRIPTION
1. You already use es6 syntax and arrow function was specifically created for this particular case so I assume it's more appropriate to use it here.
2. Detail as a property is supported only in CustomEvent interface so CustomEvent is supposed to be used whenever there is a need to extend Event obj with custom data.